### PR TITLE
Use base64 instead of xxd and display the server motd if available.

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -7,24 +7,23 @@ function sshrc() {
             files="$files .sshrc.d"
         fi
         ssh -t "$@" "
-            if [ -e /etc/motd ]; then cat /etc/motd; fi
+            if [ \"\$(base64 --help | grep -e '-D')\" != \"\" ];then echo '-D' > /tmp/b64decode; else echo '-di' > /tmp/b64decode; fi
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
-            export SSHRCCLEANUP=\$SSHHOME
-            trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
-            echo $'"$(cat "$0" | xxd -p)"' | xxd -p -r > \$SSHHOME/sshrc
+            echo $'"$(cat `which sshrc` | base64)"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/sshrc
             chmod +x \$SSHHOME/sshrc
-            echo $'"$( cat << 'EOF' | xxd -p
+            echo $'"$( cat << 'EOF' | base64
 #!/usr/bin/env bash
-exec bash --rcfile <(echo '
+bash --rcfile <(echo '
 if [ -e /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi
 if [ -e ~/.bashrc ]; then source ~/.bashrc; fi
 source '$SSHHOME'/.sshrc;
 export PATH=$PATH:'$SSHHOME'
-') "$@"
+')
 EOF
-)"' | xxd -p -r > \$SSHHOME/bashsshrc
+)"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
-            echo $'"$(tar cz -h -C $SSHHOME $files | xxd -p)"' | xxd -p -r | tar mxz -C \$SSHHOME
+            export SSHRCCLEANUP=\$SSHHOME
+            echo $'"$(tar cz -h -C $SSHHOME $files | base64)"' | base64 \$(cat /tmp/b64decode) | tar mxz -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             \$SSHHOME/bashsshrc
             rm -rf \$SSHRCCLEANUP

--- a/sshrc
+++ b/sshrc
@@ -7,6 +7,7 @@ function sshrc() {
             files="$files .sshrc.d"
         fi
         ssh -t "$@" "
+            if [ -e /etc/motd ];then cat /etc/motd; fi
             if [ \"\$(base64 --help | grep -e '-D')\" != \"\" ];then echo '-D' > /tmp/b64decode; else echo '-di' > /tmp/b64decode; fi
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
             echo $'"$(cat `which sshrc` | base64)"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/sshrc

--- a/sshrc
+++ b/sshrc
@@ -8,7 +8,7 @@ function sshrc() {
         fi
         ssh -t "$@" "
             if [ -e /etc/motd ];then cat /etc/motd; fi
-            if [ \"\$(base64 --help | grep -e '-D')\" != \"\" ];then echo '-D' > /tmp/b64decode; else echo '-di' > /tmp/b64decode; fi
+            if [ \"\$(base64 --help | grep -e '-D')\" != \"\" ];then echo '-Di' > /tmp/b64decode; else echo '-di' > /tmp/b64decode; fi
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
             echo $'"$(cat `which sshrc` | base64)"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/sshrc
             chmod +x \$SSHHOME/sshrc

--- a/sshrc
+++ b/sshrc
@@ -12,56 +12,32 @@ function sshrc() {
             exit 1
         fi
         ssh -t "$@" "
-<<<<<<< HEAD
             if [ -e /etc/motd ];then cat /etc/motd; fi
             if [ \"\$(base64 --help | grep -e '-D')\" != \"\" ];then echo '-Di' > /tmp/b64decode; else echo '-di' > /tmp/b64decode; fi
-=======
-            command -v xxd >/dev/null 2>&1 || { echo >&2 \"sshrc requires xxd to be installed on the server, but it's not. Aborting.\"; exit 1; }
-            if [ -e /etc/motd ]; then cat /etc/motd; fi
->>>>>>> upstream/master
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
             echo $'"$(cat `which sshrc` | base64)"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/sshrc
             chmod +x \$SSHHOME/sshrc
-<<<<<<< HEAD
             echo $'"$( cat << 'EOF' | base64
-=======
-
-            echo $'"$( cat << 'EOF' | xxd -p
-if [ -e /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi
-if [ -e ~/.bashrc ]; then source ~/.bashrc; fi
-export PATH=$PATH:$SSHHOME
-source $SSHHOME/.sshrc;
-EOF
-)"' | xxd -p -r > \$SSHHOME/sshrc.bashrc
-
-            echo $'"$( cat << 'EOF' | xxd -p
->>>>>>> upstream/master
 #!/usr/bin/env bash
-bash --rcfile <(echo '
+exec bash --rcfile <(echo '
 if [ -e /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi
 if [ -e ~/.bashrc ]; then source ~/.bashrc; fi
-source '$SSHHOME'/.sshrc;
 export PATH=$PATH:'$SSHHOME'
+source '$SSHHOME'/.sshrc;
 ')
 EOF
 )"' | base64 \$(cat /tmp/b64decode) > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
-<<<<<<< HEAD
             export SSHRCCLEANUP=\$SSHHOME
             echo $'"$(tar cz -h -C $SSHHOME $files | base64)"' | base64 \$(cat /tmp/b64decode) | tar mxz -C \$SSHHOME
-=======
-
-            echo $'"$(tar cz -h -C $SSHHOME $files | xxd -p)"' | xxd -p -r | tar mxz -C \$SSHHOME
->>>>>>> upstream/master
             export SSHHOME=\$SSHHOME
-            bash --rcfile \$SSHHOME/sshrc.bashrc
+            bash --rcfile \$SSHHOME/bashsshrc
             "
     else
         echo "No such file: $SSHHOME/.sshrc"
     fi
 }
 if [ $1 ]; then
-    command -v xxd >/dev/null 2>&1 || { echo >&2 "sshrc requires xxd to be installed locally, but it's not. Aborting."; exit 1; }
     sshrc $@
 else
     ssh


### PR DESCRIPTION
This will detect if the non-coreutils version of base64 is present and use the correct decode option for it. Also displays the server motd message.