### PR TITLE
Force tar to read from stdin/write to stdout

### DIFF
--- a/moshrc
+++ b/moshrc
@@ -9,7 +9,7 @@ function moshrc() {
         if [ -d $SSHHOME/.sshrc.d ]; then
             files="$files .sshrc.d"
         fi
-        SIZE=$(tar cz -h -C $SSHHOME $files | wc -c)
+        SIZE=$(tar cfz - -h -C $SSHHOME $files | wc -c)
         if [ $SIZE -gt 65536 ]; then
             echo >&2 $'.sshrc.d and .sshrc files must be less than 64kb\ncurrent size: '$SIZE' bytes'
             exit 1

--- a/moshrc
+++ b/moshrc
@@ -44,7 +44,7 @@ EOF
 )' | xxd -p -r > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'$(tar cz -h -C $SSHHOME $files | xxd -p)' | xxd -p -r | tar mxz -C \$SSHHOME
+            echo $'$(tar czf - -h -C $SSHHOME $files | xxd -p)' | xxd -p -r | tar mxzf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             bash --rcfile \$SSHHOME/sshrc.bashrc
             "

--- a/sshrc
+++ b/sshrc
@@ -48,7 +48,7 @@ EOF
                 )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'"$(tar cz -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxz -C \$SSHHOME
+            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             bash --rcfile \$SSHHOME/sshrc.bashrc
             "

--- a/sshrc
+++ b/sshrc
@@ -6,7 +6,7 @@ function sshrc() {
         if [ -d $SSHHOME/.sshrc.d ]; then
             files="$files .sshrc.d"
         fi
-        SIZE=$(tar cz -h -C $SSHHOME $files | wc -c)
+        SIZE=$(tar cfz - -h -C $SSHHOME $files | wc -c)
         if [ $SIZE -gt 65536 ]; then
             echo >&2 $'.sshrc.d and .sshrc files must be less than 64kb\ncurrent size: '$SIZE' bytes'
             exit 1


### PR DESCRIPTION
It's needed in case of tar implementations, whose default input/output is
not stdin/stdout, but some tape device.

Example FreeBSD's tar implementation.