### PR TITLE
Added last login information after motd

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -15,6 +15,7 @@ function sshrc() {
             command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
             if [ -e /etc/motd ]; then cat /etc/motd; fi
             if [ -e /etc/update-motd.d ]; then run-parts /etc/update-motd.d/ 2>/dev/null; fi
+            last -F \$USER | grep -v 'still logged in' | head -n1 | awk '{print \"Last login:\",\$4,\$5,\$6,\$7,\$8,\"from\",\$3;}'
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
             export SSHRCCLEANUP=\$SSHHOME
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0


### PR DESCRIPTION
This outputs last login information on the remote host right after motd. Eg:
`Last login: Mon Jul 25 10:51:55 2016 from 192.168.1.2`