### PR TITLE
Avoid warnings caused by BSD tar vs. GNU tar

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -57,7 +57,7 @@ EOF
                 )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - --warning=no-unknown-keyword -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
             bash --rcfile \$SSHHOME/sshrc.bashrc


### PR DESCRIPTION
When using sshrc to ssh from Mac to Linux, I get:

    tar: Ignoring unknown extended header keyword `SCHILY.dev'
    tar: Ignoring unknown extended header keyword `SCHILY.ino'
    tar: Ignoring unknown extended header keyword `SCHILY.nlink'
    tar: Ignoring unknown extended header keyword `SCHILY.dev'
    tar: Ignoring unknown extended header keyword `SCHILY.ino'
    tar: Ignoring unknown extended header keyword `SCHILY.nlink'

This PR silences these warnings that are caused by creating the
tar with BSD tar and extracting it with GNU tar.