### PR TITLE
alpine mktemp compatible

### DIFF
--- a/moshrc
+++ b/moshrc
@@ -18,7 +18,7 @@ function moshrc() {
             command -v xxd >/dev/null 2>&1 || { echo >&2 \"sshrc requires xxd to be installed on the server, but it's not. Aborting.\"; exit 1; }
             if [ -e /etc/motd ]; then cat /etc/motd; fi
             if [ -e /etc/update-motd.d ]; then run-parts /etc/update-motd.d/; fi
-            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
+            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXXXX)
             export SSHRCCLEANUP=\$SSHHOME
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
             echo $'$(cat $0 | xxd -p)' | xxd -p -r > \$SSHHOME/moshrc

--- a/sshrc
+++ b/sshrc
@@ -25,7 +25,7 @@ function sshrc() {
         ssh -t "$DOMAIN" $SSHARGS "
             command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
             $WELCOME_MSG
-            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
+            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXXXX)
             export SSHRCCLEANUP=\$SSHHOME
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
             echo $'"$(cat "$0" | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc


### PR DESCRIPTION
mktemp in alpine require at least  six X

```bash
bash-4.3$ mktemp -d -t .$(whoami).sshrc.XXXXXX
/tmp/.dev.sshrc.cbGnFl
bash-4.3$ mktemp -d -t .$(whoami).sshrc.XXXX
mktemp: Invalid argument
```