### PR TITLE
run `cat /etc/motd` or `run-parts /etc/motd.d`, not both

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -14,9 +14,13 @@ function sshrc() {
         if [ -z "$CMDARG" -a ! -e ~/.sshrc.d/.hushlogin ]; then
             WELCOME_MSG="
                 if [ ! -e ~/.hushlogin ]; then
-                    if [ -e /etc/motd ]; then cat /etc/motd; fi
-                    if [ -e /etc/update-motd.d ]; then run-parts /etc/update-motd.d/ 2>/dev/null; fi
-                    last -F \$USER 2>/dev/null | grep -v 'still logged in' | head -n1 | awk '{print \"Last login:\",\$4,\$5,\$6,\$7,\$8,\"from\",\$3;}'
+                  if [ -e /etc/motd ]; then
+                    cat /etc/motd
+                  elif [ -e /etc/update-motd.d ]; then
+                    run-parts /etc/update-motd.d/ 2>/dev/null
+                  fi
+                  last -F \$USER 2>/dev/null | grep -v 'still logged in' | \
+                    head -n1 | awk '{print \"Last login:\",\$4,\$5,\$6,\$7,\$8,\"from\",\$3;}'
                 fi
                 "
         else


### PR DESCRIPTION
Running both commands often results in the message of the day being shown twice.