### PR TITLE
Use base64 from coreutils for encoding and decoding

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -23,15 +23,15 @@ function sshrc() {
             WELCOME_MSG=""
         fi
         ssh -t "$DOMAIN" $SSHARGS "
-            command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
+            command -v base64 >/dev/null 2>&1 || { echo >&2 \"sshrc requires coreutils to be installed on the server, but it's not. Aborting.\"; exit 1; }
             $WELCOME_MSG
             export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
             export SSHRCCLEANUP=\$SSHHOME
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
-            echo $'"$(cat "$0" | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc
+            echo $'"$(cat "$0" | base64)"' | tr -s ' ' $'\n' | base64 -d > \$SSHHOME/sshrc
             chmod +x \$SSHHOME/sshrc
 
-            echo $'"$( cat << 'EOF' | openssl enc -base64
+            echo $'"$( cat << 'EOF' | base64
                 if [ -r /etc/profile ]; then source /etc/profile; fi
                 if [ -r ~/.bash_profile ]; then source ~/.bash_profile
                 elif [ -r ~/.bash_login ]; then source ~/.bash_login
@@ -40,9 +40,9 @@ function sshrc() {
                 export PATH=$PATH:$SSHHOME
                 source $SSHHOME/.sshrc;
 EOF
-                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc.bashrc
+                )"' | tr -s ' ' $'\n' | base64 -d > \$SSHHOME/sshrc.bashrc
 
-            echo $'"$( cat << 'EOF' | openssl enc -base64
+            echo $'"$( cat << 'EOF' | base64
 #!/usr/bin/env bash
                 exec bash --rcfile <(echo '
                 [ -r /etc/profile ] && source /etc/profile
@@ -54,10 +54,10 @@ EOF
                 export PATH=$PATH:'$SSHHOME'
                 ') "$@"
 EOF
-                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
+                )"' | tr -s ' ' $'\n' | base64 -d > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            echo $'"$(tar czf - -h -C $SSHHOME $files | base64)"' | tr -s ' ' $'\n' | base64 -d | tar mxzf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
             bash --rcfile \$SSHHOME/sshrc.bashrc
@@ -92,6 +92,6 @@ function sshrc_parse() {
   fi
 }
 
-command -v openssl >/dev/null 2>&1 || { echo >&2 "sshrc requires openssl to be installed locally, but it's not. Aborting."; exit 1; }
+command -v base64 >/dev/null 2>&1 || { echo >&2 "sshrc requires coreutils to be installed locally, but it's not. Aborting."; exit 1; }
 sshrc_parse "$@"
 sshrc


### PR DESCRIPTION
The data transferred to the remote servers is encoded using base64.
This commit changes the tool used to encode and decode the data from
openssl to the base64 utility.

The change was done because openssl may be missing on some systems while
base64 should always be installed as it is part coreutils.  Moreover,
openssl needs to access openssl.cnf, which is usually located somewhere
under /etc.  This part of the file system may not be accessible to the
user on some remote machines, so openssl could fail in these cases.