### PR TITLE
send also sshrc when moshrc is used

### DIFF
--- a/moshrc
+++ b/moshrc
@@ -23,6 +23,7 @@ function moshrc() {
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
             echo $'$(cat $0 | xxd -p)' | xxd -p -r > \$SSHHOME/moshrc
             chmod +x \$SSHHOME/moshrc
+            if [ \"$(type sshrc)\" != \"\" ]; then echo $'$(cat $(which sshrc)| xxd -p)' | xxd -p -r > \$SSHHOME/sshrc; chmod +x \$SSHHOME/sshrc; fi
 
             echo $'$( cat << 'EOF' | xxd -p
 if [ -e /etc/bash.bashrc ]; then source /etc/bash.bashrc; fi


### PR DESCRIPTION
When I use mosh to log in to a server,
I use ssh more to log in another server than mosh.
So that sshrc is needed to propagate .sshrc. 