### PR TITLE
fix sshrc for RancherOS

### DIFF
--- a/sshrc
+++ b/sshrc
@@ -25,7 +25,7 @@ function sshrc() {
         ssh -t "$DOMAIN" $SSHARGS "
             command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
             $WELCOME_MSG
-            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
+            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXXXX)
             export SSHRCCLEANUP=\$SSHHOME
             trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
             echo $'"$(cat "$0" | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc
@@ -57,7 +57,7 @@ EOF
                 )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
             chmod +x \$SSHHOME/bashsshrc
 
-            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | gzip -dc | tar xf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
             bash --rcfile \$SSHHOME/sshrc.bashrc


### PR DESCRIPTION
RancherOS uses binaries from BusyBox for tar and mktemp, which don't support all of the flags that sshrc currently uses.

This pull request:
 - adds two more 'X' characters to the mktemp template, because BusyBox's mktemp expects 6 'X' characters at the end of the template
 - removes the 'm' option of the tar command
 - replaces the 'z' option of the tar command with a 'gzip -dc'