### PR TITLE
Add an `exec` before the final bash execution

### DIFF
--- a/moshrc
+++ b/moshrc
@@ -46,7 +46,7 @@ EOF
 
             echo $'$(tar czf - -h -C $SSHHOME $files | xxd -p)' | xxd -p -r | tar mxzf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
-            bash --rcfile \$SSHHOME/sshrc.bashrc
+            exec bash --rcfile \$SSHHOME/sshrc.bashrc
             "
     else
         echo "No such file: $SSHHOME/.sshrc"

--- a/sshrc
+++ b/sshrc
@@ -60,7 +60,7 @@ EOF
             echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
             export SSHHOME=\$SSHHOME
             echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
-            bash --rcfile \$SSHHOME/sshrc.bashrc
+            exec bash --rcfile \$SSHHOME/sshrc.bashrc
             "
     else
         echo "No such file: $SSHHOME/.sshrc" >&2


### PR DESCRIPTION
This PR adds an `exec` before the final bash statement of each script.

It doesn't fundamentally change the way the script works ; the only difference is that the initial bash script (the one that decodes an extracts the transferred files) is now replaced by the final bash invocation (instead of forking it and just stay there waiting for it to exit)

The main benefit of this change is that you no longer have a very long and ugly line in `htop` output on the server, only what is currently the child process (`bash --rcfile /tmp/…`)